### PR TITLE
SupabaseとPrismaの連携

### DIFF
--- a/prisma/migrations/20250216062419_init/migration.sql
+++ b/prisma/migrations/20250216062419_init/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `name` on the `User` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[auth_id]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `auth_id` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "name",
+ADD COLUMN     "auth_id" TEXT NOT NULL,
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_auth_id_key" ON "User"("auth_id");

--- a/prisma/migrations/20250216070612_init/migration.sql
+++ b/prisma/migrations/20250216070612_init/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the `User` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "User";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,8 +7,3 @@ generator client {
   provider = "prisma-client-js"
 }
 
-model User {
-  id    Int    @id @default(autoincrement())
-  email String @unique
-  name  String?
-}


### PR DESCRIPTION
- Supabase Authで現在ログイン中のユーザー情報は supabase.auth.getUser() を使って取得できるため初期テーブルは削除