### PR TITLE
delete: href /#

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -170,7 +170,7 @@ export function HeaderMegaMenu() {
               withinPortal
             >
               <HoverCard.Target>
-                <a href="#" className={classes.link}>
+                <a className={classes.link}>
                   <Center inline>
                     <Box component="span" mr={5}>
                       Tech Stack
@@ -212,7 +212,7 @@ export function HeaderMegaMenu() {
               withinPortal
             >
               <HoverCard.Target>
-                <a href="#" className={classes.link}>
+                <a className={classes.link}>
                   <Center inline>
                     <Box component="span" mr={5}>
                       Docs


### PR DESCRIPTION
This pull request includes small changes to the `HeaderMegaMenu` component in `src/components/Header/Header.tsx`. The changes involve removing unnecessary `href="#"` attributes from anchor tags.

Changes to `HeaderMegaMenu` component:

* Removed `href="#"` attribute from anchor tag for "Tech Stack".
* Removed `href="#"` attribute from anchor tag for "Docs".

close #45 