### PR TITLE
ページのhydration前にdata-mantine-color-scheme属性を<html>タグに追加

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import "@mantine/core/styles.css";
-import { MantineProvider } from "@mantine/core";
+import { ColorSchemeScript, MantineProvider } from "@mantine/core";
 import { HeaderMegaMenu } from "@/components/Header/Header";
 
 export const metadata: Metadata = {
@@ -15,6 +15,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
+      <head>
+        <ColorSchemeScript defaultColorScheme="light" />
+      </head>
       <body>
         <MantineProvider>
           <HeaderMegaMenu />


### PR DESCRIPTION
This pull request includes changes to the `src/app/layout.tsx` file to enhance the application's theming capabilities by integrating the `ColorSchemeScript` from the Mantine library.

The most important changes include:

Theming enhancements:
* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L3-R3): Imported `ColorSchemeScript` from `@mantine/core` to manage color schemes.
* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R18-R20): Added `ColorSchemeScript` to the `<head>` section of the `RootLayout` function, setting the default color scheme to "light".

close #52