### PR TITLE
404ページのリダイレクト修正

### DIFF
--- a/src/app/auth/confirm/route.ts
+++ b/src/app/auth/confirm/route.ts
@@ -23,5 +23,5 @@ export async function GET(request: NextRequest) {
   }
 
   // redirect the user to an error page with some instructions
-  redirect("/error");
+  redirect("/notFoundTitle");
 }

--- a/src/app/login/action.ts
+++ b/src/app/login/action.ts
@@ -40,5 +40,5 @@ export async function signup(formData: FormData) {
     redirect("/notFoundTitle");
   }
 
-  redirect(`/auth/confirm-signup?email=${encodeURIComponent(data.email)}`);
+  redirect(`/auth/confirmSignup?email=${encodeURIComponent(data.email)}`);
 }

--- a/src/app/login/action.ts
+++ b/src/app/login/action.ts
@@ -17,7 +17,7 @@ export async function login(formData: FormData) {
   const { error } = await supabase.auth.signInWithPassword(data);
 
   if (error) {
-    redirect("/error");
+    redirect("/notFoundTitle");
   }
 
   revalidatePath("/", "layout");
@@ -37,7 +37,7 @@ export async function signup(formData: FormData) {
   const { error } = await supabase.auth.signUp(data);
 
   if (error) {
-    redirect("/error");
+    redirect("/notFoundTitle");
   }
 
   redirect(`/auth/confirm-signup?email=${encodeURIComponent(data.email)}`);

--- a/src/app/notFoundTitle/page.module.css
+++ b/src/app/notFoundTitle/page.module.css
@@ -9,7 +9,7 @@
   font-size: 38px;
   line-height: 1;
   margin-bottom: calc(1.5 * var(--mantine-spacing-xl));
-  color: var(--mantine-color-gray-2);
+  color: black;
 
   @media (max-width: 768px) {
     font-size: 32px;

--- a/src/app/notFoundTitle/page.tsx
+++ b/src/app/notFoundTitle/page.tsx
@@ -12,7 +12,7 @@ export default function ErrorPage() {
         address, or the page has been moved to another URL.
       </Text>
       <Group justify="center">
-        <Button variant="subtle" size="md">
+        <Button variant="subtle" size="md" onClick={() => history.back()}>
           Take me back to home page
         </Button>
       </Group>


### PR DESCRIPTION
This pull request includes several changes to improve error handling and user experience in the authentication flow, as well as a minor style update. The most important changes include updating redirect paths, modifying button functionality, and changing a CSS property.

Improvements to error handling and user experience:

* [`src/app/auth/confirm/route.ts`](diffhunk://#diff-2ff8e13730a5ed6500fef9175e653c4cc0145d370abcb0cd0fbeea6a04ec1f30L26-R26): Updated the redirect path from `/error` to `/notFoundTitle` in the `GET` function.
* [`src/app/login/action.ts`](diffhunk://#diff-f10d6f0b6901f46f461c5b63b575b0b27839ace8efa05f196902dbc84208381eL20-R20): Updated the redirect paths from `/error` to `/notFoundTitle` in both the `login` and `signup` functions. Additionally, changed the redirect path in the `signup` function from `/auth/confirm-signup` to `/auth/confirmSignup`. [[1]](diffhunk://#diff-f10d6f0b6901f46f461c5b63b575b0b27839ace8efa05f196902dbc84208381eL20-R20) [[2]](diffhunk://#diff-f10d6f0b6901f46f461c5b63b575b0b27839ace8efa05f196902dbc84208381eL40-R43)
* [`src/app/notFoundTitle/page.tsx`](diffhunk://#diff-631cbad6929129d9e88866d3fdefa464d09f789fe8e7c55b5b3cffd8994e7ef7L15-R15): Added an `onClick` handler to the "Take me back to home page" button to navigate back in history.

Style update:

* [`src/app/notFoundTitle/page.module.css`](diffhunk://#diff-0314d5ab5624fd5d168ab111f98309927534aab1db6f7b6768c647d061290181L12-R12): Changed the text color from `var(--mantine-color-gray-2)` to `black`.

close #69