### PR TITLE
ヘッダーのリンクの修正

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -13,3 +13,25 @@
   padding-bottom: var(--mantine-spacing-xl);
   border-top: 1px solid light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
 }
+.link {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding-left: var(--mantine-spacing-md);
+  padding-right: var(--mantine-spacing-md);
+  text-decoration: none;
+  color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+  font-weight: 500;
+  font-size: var(--mantine-font-size-sm);
+
+  @media (max-width: 600px) {
+    height: 42px;
+    width: 100%;
+  }
+}
+
+.subLink {
+  width: 100%;
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+  border-radius: var(--mantine-radius-md);
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -75,7 +75,7 @@ const techStackMockdata = [
   },
 ];
 
-const docsMockdata = [
+const dashBoardMockdata = [
   {
     icon: IconBolt,
     title: "Supabase dashboard",
@@ -118,7 +118,7 @@ export function HeaderMegaMenu() {
     </Anchor>
   ));
 
-  const docsLinks = docsMockdata.map((item) => (
+  const dashBoardLinks = dashBoardMockdata.map((item) => (
     <Anchor
       href={item.link}
       key={item.title}
@@ -204,7 +204,7 @@ export function HeaderMegaMenu() {
                 <a className={styles.link}>
                   <Center inline>
                     <Box component="span" mr={5}>
-                      Docs
+                      DashBoard
                     </Box>
                     <IconChevronDown size={16} color={theme.colors.blue[6]} />
                     </Center>
@@ -212,13 +212,13 @@ export function HeaderMegaMenu() {
             </HoverCard.Target>
             <HoverCard.Dropdown style={{ overflow: 'hidden' }}>
               <Group justify="space-between" px="md">
-                <Text fw={500}>Docs</Text>
+                <Text fw={500}>dashBoard</Text>
               </Group>
 
               <Divider my="sm" />
 
               <SimpleGrid cols={2} spacing={0}>
-                {docsLinks}
+                {dashBoardLinks}
               </SimpleGrid>
             </HoverCard.Dropdown>
           </HoverCard>
@@ -260,12 +260,12 @@ export function HeaderMegaMenu() {
           <UnstyledButton onClick={toggleLinks} className={styles.link}>
             <Center inline>
               <Box component="span" mr={5}>
-                Docs
+                DashBoard
               </Box>
               <IconChevronDown size={16} color={theme.colors.blue[6]} />
             </Center>
           </UnstyledButton>
-          <Collapse in={linksOpened}>{docsLinks}</Collapse>
+          <Collapse in={linksOpened}>{dashBoardLinks}</Collapse>
           <Divider my="sm" />
           <Group justify="center" grow pb="xl" px="md">
             <Button variant="default" onClick={handleLogout}>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -157,17 +157,11 @@ export function HeaderMegaMenu() {
     <Box>
       <header className={styles.header}>
         <Group justify="space-between" h="100%">
-          <h3>Next-Hono-Template</h3>
+        <h3>Next-Hono-Template</h3>
           <Group h="100%" gap={0} visibleFrom="sm">
-            <HoverCard
-              width={600}
-              position="bottom"
-              radius="md"
-              shadow="md"
-              withinPortal
-            >
+            <HoverCard width={600} position="bottom" radius="md" shadow="md" withinPortal>
               <HoverCard.Target>
-                <a>
+                <a className={styles.link}>
                   <Center inline>
                     <Box component="span" mr={5}>
                       Tech Stack
@@ -176,14 +170,18 @@ export function HeaderMegaMenu() {
                   </Center>
                 </a>
               </HoverCard.Target>
-              <HoverCard.Dropdown style={{ overflow: "hidden" }}>
+
+              <HoverCard.Dropdown style={{ overflow: 'hidden' }}>
                 <Group justify="space-between" px="md">
-                  <Text fw={500}>Teck Stack</Text>
+                  <Text fw={500}>Tech Stack</Text>
                 </Group>
+
                 <Divider my="sm" />
+
                 <SimpleGrid cols={2} spacing={0}>
                   {techStackLinks}
                 </SimpleGrid>
+
                 <div className={styles.dropdownFooter}>
                   <Group justify="space-between">
                     <div>
@@ -191,68 +189,66 @@ export function HeaderMegaMenu() {
                         Get started
                       </Text>
                       <Text size="xs" c="dimmed">
-                        Get started with GitHub source code and your project
+                      Get started with GitHub source code and your project
                       </Text>
                     </div>
                     <Anchor href="https://github.com/Sho0226/Next-Hono-Template">
-                      <Button variant="default">Get started</Button>
+                    <Button variant="default">Get started</Button>
                     </Anchor>
                   </Group>
                 </div>
               </HoverCard.Dropdown>
             </HoverCard>
-            <HoverCard
-              width={600}
-              position="bottom"
-              radius="md"
-              shadow="md"
-              withinPortal
-            >
+            <HoverCard width={600} position="bottom" radius="md" shadow="md" withinPortal>
               <HoverCard.Target>
-                <a>
+                <a className={styles.link}>
                   <Center inline>
                     <Box component="span" mr={5}>
                       Docs
                     </Box>
                     <IconChevronDown size={16} color={theme.colors.blue[6]} />
-                  </Center>
+                    </Center>
                 </a>
-              </HoverCard.Target>
-              <HoverCard.Dropdown style={{ overflow: "hidden" }}>
-                <Group justify="space-between" px="md">
-                  <Text fw={500}>Docs</Text>
-                </Group>
-                <Divider my="sm" />
-                <SimpleGrid cols={2} spacing={0}>
-                  {docsLinks}
-                </SimpleGrid>
-              </HoverCard.Dropdown>
-            </HoverCard>
+            </HoverCard.Target>
+            <HoverCard.Dropdown style={{ overflow: 'hidden' }}>
+              <Group justify="space-between" px="md">
+                <Text fw={500}>Docs</Text>
+              </Group>
+
+              <Divider my="sm" />
+
+              <SimpleGrid cols={2} spacing={0}>
+                {docsLinks}
+              </SimpleGrid>
+            </HoverCard.Dropdown>
+          </HoverCard>
           </Group>
+
           <Group visibleFrom="sm">
             <Button variant="default" onClick={handleLogout}>
               Log out
             </Button>
           </Group>
           <Burger
-            opened={drawerOpened}
-            onClick={toggleDrawer}
-            hiddenFrom="sm"
+           opened={drawerOpened}
+           onClick={toggleDrawer}
+           hiddenFrom="sm" 
           />
         </Group>
       </header>
+
       <Drawer
         opened={drawerOpened}
         onClose={closeDrawer}
         size="100%"
         padding="md"
-        title="Menu"
+        title="Navigation"
         hiddenFrom="sm"
         zIndex={1000000}
       >
         <ScrollArea h="calc(100vh - 80px" mx="-md">
           <Divider my="sm" />
-          <UnstyledButton onClick={toggleLinks}>
+          <UnstyledButton className={styles.link} onClick={toggleLinks}>
             <Center inline>
               <Box component="span" mr={5}>
                 Tech Stack
@@ -261,7 +257,7 @@ export function HeaderMegaMenu() {
             </Center>
           </UnstyledButton>
           <Collapse in={linksOpened}>{techStackLinks}</Collapse>
-          <UnstyledButton onClick={toggleLinks}>
+          <UnstyledButton onClick={toggleLinks} className={styles.link}>
             <Center inline>
               <Box component="span" mr={5}>
                 Docs


### PR DESCRIPTION
This pull request makes several updates to the `Header` component, including style adjustments and renaming variables to improve clarity. The most important changes include adding new CSS classes, renaming mock data and related variables, and enhancing the structure of the `HeaderMegaMenu` function.

Styling improvements:

* Added new CSS classes `.link` and `.subLink` to `Header.module.css` to style links and sub-links within the header. (`src/components/Header/Header.module.css` - [src/components/Header/Header.module.cssR16-R37](diffhunk://#diff-c281c17f0d969030d43c3bc7daf6634b377706ea76941902f8d0bb03295bfa73R16-R37))

Codebase improvements:

* Renamed `docsMockdata` to `dashBoardMockdata` to better reflect its purpose. (`src/components/Header/Header.tsx` - [src/components/Header/Header.tsxL78-R78](diffhunk://#diff-08f1eeca099377b71b51c70a42d155ddf8d0d6152e3961b53402a482f70c280cL78-R78))
* Updated variable names from `docsLinks` to `dashBoardLinks` to align with the new mock data naming. (`src/components/Header/Header.tsx` - [src/components/Header/Header.tsxL121-R121](diffhunk://#diff-08f1eeca099377b71b51c70a42d155ddf8d0d6152e3961b53402a482f70c280cL121-R121))
* Applied the new `.link` CSS class to anchor tags within `HoverCard` components for consistent styling. (`src/components/Header/Header.tsx` - [[1]](diffhunk://#diff-08f1eeca099377b71b51c70a42d155ddf8d0d6152e3961b53402a482f70c280cL162-R164) [[2]](diffhunk://#diff-08f1eeca099377b71b51c70a42d155ddf8d0d6152e3961b53402a482f70c280cL204-R226)
* Changed the `Drawer` title from "Menu" to "Navigation" for better clarity. (`src/components/Header/Header.tsx` - [src/components/Header/Header.tsxR239-R251](diffhunk://#diff-08f1eeca099377b71b51c70a42d155ddf8d0d6152e3961b53402a482f70c280cR239-R251))

close #68 