### PR TITLE
パスワードリセットURLを本番用に差し替え

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_SUPABASE_URL=https://xxxxxxxxxxx.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-API-key
 DATABASE_URL=prisma+postgres://accelerate.prisma-data.net/?api_key=xxxxxxxx
+RESET_REDIRECT_URL=https://localhost:3000/auth/password/reset

--- a/src/app/auth/password/form/action.ts
+++ b/src/app/auth/password/form/action.ts
@@ -12,7 +12,7 @@ export async function forgotPassword(formData: FormData) {
   };
 
   const { error } = await supabase.auth.resetPasswordForEmail(data.email, {
-    redirectTo: "http://localhost:3000/auth/password/reset",
+    redirectTo: process.env.RESET_REDIRECT_URL,
   });
   if (error) {
     throw error;


### PR DESCRIPTION
This pull request includes changes to improve the password reset functionality by making the redirect URL configurable through environment variables.

Configuration improvements:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR4): Added `RESET_REDIRECT_URL` to allow configuration of the password reset redirect URL.

Code improvements:

* [`src/app/auth/password/form/action.ts`](diffhunk://#diff-d1cfa9536cb459c2ff45a01bc6b0fad23ef1f902c5b7bb608868edfd50791b01L15-R15): Updated the `redirectTo` parameter in the `resetPasswordForEmail` function to use the `RESET_REDIRECT_URL` environment variable.

close #81 