### PR TITLE
apiのTryCatch書き換え

### DIFF
--- a/src/app/api/[[...route]]/route.ts
+++ b/src/app/api/[[...route]]/route.ts
@@ -7,12 +7,6 @@ export const runtime = "edge";
 const app = new Hono().basePath("/api");
 const prisma = new PrismaClient();
 
-app.get("/hello", (c) => {
-  return c.json({
-    message: "Hello Next.js!",
-  });
-});
-
 app.get("/todos", async (c) => {
   const todos = await prisma.todo.findMany();
   return c.json(todos);
@@ -35,38 +29,26 @@ app.post("/todos", async (c) => {
 app.put("/todos/:id", async (c) => {
   const id = parseInt(c.req.param("id"), 10);
   if (isNaN(id)) {
-    return c.json({ error: "Invalid ID" }, 400); // IDが数値でない場合はエラー
+    return c.json({ error: "Invalid ID" }, 400);
   }
   const body = await c.req.json();
   const { done } = body;
-
   if (typeof done !== "boolean") {
     return c.json({ error: "Done is required" }, 400);
   }
-
-  try {
-    const updatedTodo = await prisma.todo.update({
-      where: { id },
-      data: { done },
-    });
-    return c.json(updatedTodo);
-  } catch (error) {
-    console.error("Error updating todo:", error);
-    return c.json({ error: "Failed to update todo" }, 500);
-  }
+  const updatedTodo = await prisma.todo.update({
+    where: { id },
+    data: { done },
+  });
+  return c.json(updatedTodo);
 });
 
 app.delete("/todos/:id", async (c) => {
   const id = parseInt(c.req.param("id"), 10);
-  try {
-    await prisma.todo.delete({
-      where: { id },
-    });
-    return c.json({ message: "Todo deleted" });
-  } catch (error) {
-    console.error("Error deleting todo:", error);
-    return c.json({ error: "Failed to delete todo" }, 500);
-  }
+  await prisma.todo.delete({
+    where: { id },
+  });
+  return c.json({ message: "Todo deleted" });
 });
 
 export const GET = handle(app);


### PR DESCRIPTION
This pull request includes changes to the `s#88 c/app/api/[[...route]]/route.ts` file to simplify and clean up the codebase by removing unused routes and redundant error handling.

Codebase simplification:

* Removed the unused `/hello` route from the `app.get` method. ([src/app/api/[[...route]]/route.tsL10-L15](diffhunk://#diff-087a4afc4f41c98907de10383d7019c624a5216fdf90a1496a3cef40fb87227dL10-L15))
* Simplified the `app.put` method for updating a todo by removing redundant error handling for the update operation. ([src/app/api/[[...route]]/route.tsL38-L69](diffhunk://#diff-087a4afc4f41c98907de10383d7019c624a5216fdf90a1496a3cef40fb87227dL38-L69))
* Simplified the `app.delete` method for deleting a todo by removing redundant error handling for the delete operation. ([src/app/api/[[...route]]/route.tsL38-L69](diffhunk://#diff-087a4afc4f41c98907de10383d7019c624a5216fdf90a1496a3cef40fb87227dL38-L69))

close #