### PR TITLE
パスワードリセット時のテキスト修正

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 name: CI & Deploy Preview to Vercel
 
+permissions:
+  pull-requests: write
+
 on:
   push:
   pull_request:
@@ -37,5 +40,5 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          github-comment: 'true'
+          github-comment: "true"
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -10,14 +10,12 @@ export default function LoginPage({
     <div className={styles.container}>
       <div className={styles.card}>
         {searchParams.error && (
-          <div className={styles.error}>
-            {searchParams.error}
-          </div>
+          <div className={styles.error}>{searchParams.error}</div>
         )}
         <form method="post" className={styles.form}>
           <div>
             <label htmlFor="email" className={styles.label}>
-              Email:
+              メールアドレス:
             </label>
             <input
               id="email"
@@ -30,7 +28,7 @@ export default function LoginPage({
 
           <div>
             <label htmlFor="password" className={styles.label}>
-              Password:
+              パスワード:
             </label>
             <input
               id="password"
@@ -46,13 +44,13 @@ export default function LoginPage({
               formAction={login}
               className={`${styles.button} ${styles.loginButton}`}
             >
-              Log in
+              ログイン
             </button>
             <button
               formAction={signup}
               className={`${styles.button} ${styles.signupButton}`}
             >
-              Sign up
+              サインアップ
             </button>
           </div>
         </form>

--- a/src/app/auth/password/form/page.tsx
+++ b/src/app/auth/password/form/page.tsx
@@ -15,7 +15,7 @@ export default function forgotPasswordPage() {
         <form method="post" className={styles.form}>
           <div>
             <label htmlFor="email" className={styles.label}>
-              Email:
+              メールアドレス:
             </label>
             <input
               id="email"

--- a/src/app/auth/password/reset/page.tsx
+++ b/src/app/auth/password/reset/page.tsx
@@ -37,12 +37,12 @@ export default function ResetPasswordPage() {
   return (
     <div className={styles.container}>
       <div className={styles.card}>
-        <h2 className={styles.title}>reset your Password</h2>
+        <h2 className={styles.title}>パスワードをリセット</h2>
         <p className={styles.text}>新しいパスワードを入力してください</p>
         <form method="post" className={styles.form} onSubmit={handleSubmit}>
           <div>
             <label htmlFor="newPassword" className={styles.label}>
-              new Password:
+              新しいパスワード:
             </label>
             <input
               id="newPassword"
@@ -54,7 +54,7 @@ export default function ResetPasswordPage() {
           </div>
           <div>
             <label htmlFor="confirmPassword" className={styles.label}>
-              confirm new Password:
+              新しいパスワード(確認):
             </label>
             <input
               id="confirmPassword"
@@ -68,7 +68,7 @@ export default function ResetPasswordPage() {
             type="submit"
             className={`${styles.button} ${styles.submitButton}`}
           >
-            submit
+            送信
           </button>
         </form>
       </div>

--- a/src/app/auth/password/reset/page.tsx
+++ b/src/app/auth/password/reset/page.tsx
@@ -37,12 +37,12 @@ export default function ResetPasswordPage() {
   return (
     <div className={styles.container}>
       <div className={styles.card}>
-        <h2 className={styles.title}>パスワードをリセット</h2>
-        <p className={styles.text}>新しいパスワードを入力してください。</p>
+        <h2 className={styles.title}>reset your Password</h2>
+        <p className={styles.text}>新しいパスワードを入力してください</p>
         <form method="post" className={styles.form} onSubmit={handleSubmit}>
           <div>
             <label htmlFor="newPassword" className={styles.label}>
-              新しいパスワード:
+              new Password:
             </label>
             <input
               id="newPassword"
@@ -54,7 +54,7 @@ export default function ResetPasswordPage() {
           </div>
           <div>
             <label htmlFor="confirmPassword" className={styles.label}>
-              新しいパスワードの確認:
+              confirm new Password:
             </label>
             <input
               id="confirmPassword"
@@ -68,7 +68,7 @@ export default function ResetPasswordPage() {
             type="submit"
             className={`${styles.button} ${styles.submitButton}`}
           >
-            送信
+            submit
           </button>
         </form>
       </div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -219,7 +219,7 @@ export function HeaderMegaMenu() {
 
           <Group visibleFrom="sm">
             <Button variant="default" onClick={handleLogout}>
-              Log out
+              ログアウト
             </Button>
           </Group>
           <Burger
@@ -235,7 +235,7 @@ export function HeaderMegaMenu() {
         onClose={closeDrawer}
         size="100%"
         padding="md"
-        title="Navigation"
+        title="ナビゲーション"
         hiddenFrom="sm"
         zIndex={1000000}
       >
@@ -262,7 +262,7 @@ export function HeaderMegaMenu() {
           <Divider my="sm" />
           <Group justify="center" grow pb="xl" px="md">
             <Button variant="default" onClick={handleLogout}>
-              Log out
+              ログアウト
             </Button>
           </Group>
         </ScrollArea>


### PR DESCRIPTION
This pull request updates the `ResetPasswordPage` component in `src/app/auth/password/reset/page.tsx` to standardize the text content by switching from Japanese to English for certain elements. The most important changes are as follows:

### Text updates for localization:

* Changed the title text from "パスワードをリセット" to "reset your Password" (`h2` element).
* Updated the label for the new password input field from "新しいパスワード:" to "new Password:".
* Updated the label for the confirm password input field from "新しいパスワードの確認:" to "confirm new Password:".
* Changed the button text from "送信" to "submit".

close #106 

# DEMO
<img width="1467" alt="image" src="https://github.com/user-attachments/assets/a4aaf8eb-3ab0-4765-8927-4aa922373cf3" />
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/3435e343-1e7d-4fd1-96ed-9886d479a9a2" />
<img width="346" alt="image" src="https://github.com/user-attachments/assets/9a22fbb7-6d0c-47f5-a053-5e12c8777265" />

