### PR TITLE
feat: ログイン時にはユーザー情報を表示するように

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: CI & Deploy Preview to Vercel
+name: CI
 
 permissions:
   pull-requests: write
@@ -28,18 +28,3 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run format
-
-  Deploy-Preview:
-    name: Deploy Preview to Vercel
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v3
-      - uses: amondnet/vercel-action@v25.2.0
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          github-comment: "true"
-          github-token: ${{ github.token }}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,34 +1,36 @@
-import type { Metadata } from "next";
-import "@mantine/core/styles.css";
-import "../../styles/globals.css";
-import { ColorSchemeScript, MantineProvider } from "@mantine/core";
 import { HeaderMegaMenu } from "@/components/Header/Header";
+import { createClient } from "@/lib/supabase/server";
+import { ColorSchemeScript, MantineProvider } from "@mantine/core";
+import "@mantine/core/styles.css";
 import { Analytics } from "@vercel/analytics/next";
-import { SupabaseProvider } from "@/components/SupabaseProvider/SupabaseProvider";
+import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Next-Hono-Template",
   description: "A modern template combining Next.js and Hono.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
   return (
     <html lang="ja">
       <head>
         <ColorSchemeScript defaultColorScheme="light" />
       </head>
       <body>
-        <SupabaseProvider>
-          <MantineProvider>
-            <HeaderMegaMenu />
-            {children}
-            <Analytics />
-          </MantineProvider>
-        </SupabaseProvider>
+        <MantineProvider>
+          <HeaderMegaMenu user={user} />
+          {children}
+          <Analytics />
+        </MantineProvider>
       </body>
     </html>
   );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,14 +1,5 @@
 "use client";
 import {
-  IconBolt,
-  IconBrandNextjs,
-  IconBrandPrisma,
-  IconBrandReact,
-  IconBrandTypescript,
-  IconBrandVercel,
-  IconChevronDown,
-} from "@tabler/icons-react";
-import {
   Anchor,
   Box,
   Burger,
@@ -27,9 +18,18 @@ import {
   useMantineTheme,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { User } from "@supabase/supabase-js";
+import {
+  IconBolt,
+  IconBrandNextjs,
+  IconBrandPrisma,
+  IconBrandReact,
+  IconBrandTypescript,
+  IconBrandVercel,
+  IconChevronDown,
+} from "@tabler/icons-react";
+import { UserButton } from "../UserButton/UserButton";
 import styles from "./Header.module.css";
-import { Logout } from "@/app/auth/logout/action";
-import { useRouter } from "next/navigation";
 
 const techStackMockdata = [
   {
@@ -91,17 +91,12 @@ const dashBoardMockdata = [
     link: "https://cloud.prisma.io/",
   },
 ];
-export function HeaderMegaMenu() {
-  const router = useRouter();
+export function HeaderMegaMenu({ user }: { user: User | null }) {
   const [drawerOpened, { toggle: toggleDrawer, close: closeDrawer }] =
     useDisclosure(false);
   const [techStackOpened, { toggle: toggleTechStack }] = useDisclosure(false);
   const [dashBoardOpened, { toggle: toggleDashBoard }] = useDisclosure(false);
   const theme = useMantineTheme();
-  const handleLogout = () => {
-    Logout();
-    router.refresh();
-  };
 
   const techStackLinks = techStackMockdata.map((item) => (
     <Anchor href={item.link} key={item.title} target="_blank">
@@ -218,9 +213,7 @@ export function HeaderMegaMenu() {
           </Group>
 
           <Group visibleFrom="sm">
-            <Button variant="default" onClick={handleLogout}>
-              ログアウト
-            </Button>
+            <UserButton user={user} />
           </Group>
           <Burger
             opened={drawerOpened}
@@ -237,7 +230,7 @@ export function HeaderMegaMenu() {
         padding="md"
         title="ナビゲーション"
         hiddenFrom="sm"
-        zIndex={1000000}
+        zIndex={100}
       >
         <ScrollArea h="calc(100vh - 80px" mx="-md">
           <Divider my="sm" />
@@ -261,9 +254,7 @@ export function HeaderMegaMenu() {
           <Collapse in={dashBoardOpened}>{dashBoardLinks}</Collapse>
           <Divider my="sm" />
           <Group justify="center" grow pb="xl" px="md">
-            <Button variant="default" onClick={handleLogout}>
-              ログアウト
-            </Button>
+            <UserButton user={user} />
           </Group>
         </ScrollArea>
       </Drawer>

--- a/src/components/UserButton/UserButton.tsx
+++ b/src/components/UserButton/UserButton.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Logout } from "@/app/auth/logout/action";
+import { Avatar, Button, Group, Menu, Text } from "@mantine/core";
+import { User } from "@supabase/supabase-js";
+import { IconChevronRight, IconLogout } from "@tabler/icons-react";
+import { useRouter } from "next/navigation";
+
+export function UserButton({ user }: { user: User | null }) {
+  const router = useRouter();
+
+  const handleLogin = () => {
+    router.push("/auth/login");
+  };
+
+  const handleLogout = async () => {
+    await Logout();
+    router.refresh();
+  };
+
+  if (!user) {
+    return (
+      <Button variant="default" onClick={handleLogin}>
+        ログイン
+      </Button>
+    );
+  }
+
+  return (
+    <Menu shadow="md" width={200}>
+      <Menu.Target>
+        <Button variant="transparent" w="100%">
+          <Group wrap="nowrap" w="100%">
+            <Avatar src={user?.user_metadata.avatar_url} radius="xl" />
+
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <Text c="dimmed" size="xs" truncate="end">
+                {user?.user_metadata.email}
+              </Text>
+            </div>
+
+            <IconChevronRight size={14} stroke={1.5} />
+          </Group>
+        </Button>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <Menu.Item
+          leftSection={<IconLogout size={14} />}
+          onClick={handleLogout}
+          color="red"
+        >
+          ログアウト
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/src/components/UserButton/UserButton.tsx
+++ b/src/components/UserButton/UserButton.tsx
@@ -4,10 +4,11 @@ import { Logout } from "@/app/auth/logout/action";
 import { Avatar, Button, Group, Menu, Text } from "@mantine/core";
 import { User } from "@supabase/supabase-js";
 import { IconChevronRight, IconLogout } from "@tabler/icons-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 export function UserButton({ user }: { user: User | null }) {
   const router = useRouter();
+  const pathname = usePathname();
 
   const handleLogin = () => {
     router.push("/auth/login");
@@ -17,6 +18,10 @@ export function UserButton({ user }: { user: User | null }) {
     await Logout();
     router.refresh();
   };
+
+  if (pathname === "/auth/login") {
+    return null;
+  }
 
   if (!user) {
     return (


### PR DESCRIPTION
## 概要
常にログアウトボタンが表示されていたため、非ログイン時とログイン時で表示するボタンを分けるように

非ログイン時:
![スクリーンショット 2025-04-21 4 43 03](https://github.com/user-attachments/assets/5bf11117-a02a-490a-a4b4-19f600b1b041)

ログイン時:
![スクリーンショット 2025-04-21 4 43 43](https://github.com/user-attachments/assets/fae04f55-0691-450d-8f98-67d5d66e8d97)

close #94 
