### PR TITLE
fix:モバイル版ログアウト時にメニュー閉じるように

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -100,6 +100,7 @@ export function HeaderMegaMenu() {
   const theme = useMantineTheme();
   const handleLogout = () => {
     Logout();
+    closeDrawer();
     router.refresh();
   };
 


### PR DESCRIPTION
ナビゲーションバーをログアウトボタン押した際に閉じて自然な挙動に直しました。
close #97 